### PR TITLE
Fixed error in generating operational test tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fixed error in generating operational test tasks
+
 ## [4.1.0-pre.3] - 2019-08-06
 
 ### Added

--- a/provisioners/ansible/playbooks/includes/operational-tasks-gen.yaml
+++ b/provisioners/ansible/playbooks/includes/operational-tasks-gen.yaml
@@ -23,6 +23,46 @@
     - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
     - "{{ operational_tasks_jobs_trimmed.results }}"
 
+- name: "Generate aem-test-suite jobs with basic params for operational-tasks directories"
+  file:
+    path: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/operational-tasks/{{ item[0].item.path }}/{{ item[1] }}/{{ item[2].item.path }}
+    state: directory
+    mode: '0776'
+  with_nested:
+    - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
+    - "{{ operational_tasks_with_aem_test_suite_basic_params }}"
+    - "{{ aem_test_suite_profiles_trimmed.results }}"
+
+- name: "Generate aem-test-suite jobs with aem architecture params for operational-tasks directories"
+  file:
+    path: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/operational-tasks/{{ item[0].item.path }}/{{ item[1] }}/{{ item[2].item.path }}
+    state: directory
+    mode: '0776'
+  with_nested:
+    - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
+    - "{{ operational_tasks_with_aem_test_suite_aem_architecture_params }}"
+    - "{{ aem_test_suite_profiles_trimmed.results }}"
+
+- name: "Generate aem-test-suite jobs with recovery params for operational-tasks directories"
+  file:
+    path: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/operational-tasks/{{ item[0].item.path }}/{{ item[1] }}/{{ item[2].item.path }}
+    state: directory
+    mode: '0776'
+  with_nested:
+    - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
+    - "{{ operational_tasks_with_aem_test_suite_recovery_params }}"
+    - "{{ aem_test_suite_profiles_trimmed.results }}"
+
+- name: "Generate aem-test-suite jobs with security params for operational-tasks directories"
+  file:
+    path: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/operational-tasks/{{ item[0].item.path }}/{{ item[1] }}/{{ item[2].item.path }}
+    state: directory
+    mode: '0776'
+  with_nested:
+    - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
+    - "{{ operational_tasks_with_aem_test_suite_security_params }}"
+    - "{{ aem_test_suite_profiles_trimmed.results }}"
+
 - name: "Generate jobs for operational-tasks configuration profile config.xml"
   template:
     src: '../../../templates/ansible/jenkins/config/category-config-profile.xml.j2'
@@ -31,6 +71,42 @@
   with_nested:
     - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
     - "{{ operational_tasks_jobs_trimmed.results }}"
+
+- name: "Generate aem-test-suite jobs with basic params for operational-tasks category config.xml"
+  template:
+    src: '../../../templates/ansible/jenkins/config/category-operational-tasks-aem-test-suite.xml.j2'
+    dest: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/operational-tasks/{{ item[0].item.path }}/{{ item[1] }}/config.xml
+    mode: '0644'
+  with_nested:
+    - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
+    - "{{ operational_tasks_with_aem_test_suite_basic_params }}"
+
+- name: "Generate aem-test-suite jobs with aem architecture pa for operational-tasks category config.xml"
+  template:
+    src: '../../../templates/ansible/jenkins/config/category-operational-tasks-aem-test-suite.xml.j2'
+    dest: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/operational-tasks/{{ item[0].item.path }}/{{ item[1] }}/config.xml
+    mode: '0644'
+  with_nested:
+    - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
+    - "{{ operational_tasks_with_aem_test_suite_aem_architecture_params }}"
+
+- name: "Generate aem-test-suite jobs with recovery params for operational-tasks category config.xml"
+  template:
+    src: '../../../templates/ansible/jenkins/config/category-operational-tasks-aem-test-suite.xml.j2'
+    dest: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/operational-tasks/{{ item[0].item.path }}/{{ item[1] }}/config.xml
+    mode: '0644'
+  with_nested:
+    - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
+    - "{{ operational_tasks_with_aem_test_suite_recovery_params }}"
+
+- name: "Generate aem-test-suite jobs with security params for operational-tasks category config.xml"
+  template:
+    src: '../../../templates/ansible/jenkins/config/category-operational-tasks-aem-test-suite.xml.j2'
+    dest: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/operational-tasks/{{ item[0].item.path }}/{{ item[1] }}/config.xml
+    mode: '0644'
+  with_nested:
+    - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
+    - "{{ operational_tasks_with_aem_test_suite_security_params }}"
 
 - name: "Generate jobs for operational-tasks config.xml for basic jobs"
   template:
@@ -138,35 +214,39 @@
 - name: "Generate jobs for operational-tasks config.xml for jobs with AEM Test Suite basic parameter"
   template:
     src: '../../../templates/ansible/jenkins/config/jobs-operational-tasks-test.xml.j2'
-    dest: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/operational-tasks/{{ item[0].item.path }}/{{ item[1] }}/config.xml
+    dest: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/operational-tasks/{{ item[0].item.path }}/{{ item[1] }}/{{ item[2].item.path }}/config.xml
     mode: '0644'
   with_nested:
-    - "{{ aem_test_suite_profiles_trimmed.results }}"
+    - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
     - "{{ operational_tasks_with_aem_test_suite_basic_params }}"
+    - "{{ aem_test_suite_profiles_trimmed.results }}"
 
-- name: "Generate jobs for operational-tasks config.xml for jobs with AEM Test Suite AEM architecture parameter"
+- name: "Generate jobs for operational-tasks config.xml for jobs with AEM Test Suite aem architecture parameter"
   template:
     src: '../../../templates/ansible/jenkins/config/jobs-operational-tasks-test-architecture-type.xml.j2'
-    dest: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/operational-tasks/{{ item[0].item.path }}/{{ item[1] }}/config.xml
+    dest: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/operational-tasks/{{ item[0].item.path }}/{{ item[1] }}/{{ item[2].item.path }}/config.xml
     mode: '0644'
   with_nested:
-    - "{{ aem_test_suite_profiles_trimmed.results }}"
+    - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
     - "{{ operational_tasks_with_aem_test_suite_aem_architecture_params }}"
+    - "{{ aem_test_suite_profiles_trimmed.results }}"
 
-- name: "Generate jobs for operational-tasks config.xml for jobs with AEM Test Suite AEM architecture parameter"
+- name: "Generate jobs for operational-tasks config.xml for jobs with AEM Test Suite recovery parameter"
   template:
     src: '../../../templates/ansible/jenkins/config/jobs-operational-tasks-test-recovery.xml.j2'
-    dest: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/operational-tasks/{{ item[0].item.path }}/{{ item[1] }}/config.xml
+    dest: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/operational-tasks/{{ item[0].item.path }}/{{ item[1] }}/{{ item[2].item.path }}/config.xml
     mode: '0644'
   with_nested:
-    - "{{ aem_test_suite_profiles_trimmed.results }}"
+    - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
     - "{{ operational_tasks_with_aem_test_suite_recovery_params }}"
+    - "{{ aem_test_suite_profiles_trimmed.results }}"
 
-- name: "Generate jobs for operational-tasks config.xml for jobs with AEM Test Suite AEM architecture parameter"
+- name: "Generate jobs for operational-tasks config.xml for jobs with AEM Test Suite secyrity parameter"
   template:
     src: '../../../templates/ansible/jenkins/config/jobs-operational-tasks-test-aem-security.xml.j2'
-    dest: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/operational-tasks/{{ item[0].item.path }}/{{ item[1] }}/config.xml
+    dest: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/operational-tasks/{{ item[0].item.path }}/{{ item[1] }}/{{ item[2].item.path }}/config.xml
     mode: '0644'
   with_nested:
-    - "{{ aem_test_suite_profiles_trimmed.results }}"
+    - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
     - "{{ operational_tasks_with_aem_test_suite_security_params }}"
+    - "{{ aem_test_suite_profiles_trimmed.results }}"

--- a/templates/ansible/jenkins/config/category-operational-tasks-aem-test-suite.xml.j2
+++ b/templates/ansible/jenkins/config/category-operational-tasks-aem-test-suite.xml.j2
@@ -1,0 +1,29 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<com.cloudbees.hudson.plugins.folder.Folder plugin="cloudbees-folder@6.7">
+  <description>AEM OpenCloud configuration profile Jenkins folder provisioned with AEM OpenCloud Manager.</description>
+  <displayName>{{ item[1] | regex_replace('.*/(?=)', '') }}</displayName>
+  <properties>
+    <org.jenkinsci.plugins.pipeline.modeldefinition.config.FolderConfig plugin="pipeline-model-definition@1.3.4">
+      <dockerLabel></dockerLabel>
+      <registry plugin="docker-commons@1.13"/>
+    </org.jenkinsci.plugins.pipeline.modeldefinition.config.FolderConfig>
+  </properties>
+  <folderViews class="com.cloudbees.hudson.plugins.folder.views.DefaultFolderViewHolder">
+    <views>
+      <hudson.model.AllView>
+        <owner class="com.cloudbees.hudson.plugins.folder.Folder" reference="../../../.."/>
+        <name>All</name>
+        <filterExecutors>false</filterExecutors>
+        <filterQueue>false</filterQueue>
+        <properties class="hudson.model.View$PropertyList"/>
+      </hudson.model.AllView>
+    </views>
+    <tabBar class="hudson.views.DefaultViewsTabBar"/>
+  </folderViews>
+  <healthMetrics>
+    <com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
+      <nonRecursive>false</nonRecursive>
+    </com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
+  </healthMetrics>
+  <icon class="com.cloudbees.hudson.plugins.folder.icons.StockFolderIcon"/>
+</com.cloudbees.hudson.plugins.folder.Folder>

--- a/templates/ansible/jenkins/config/jobs-operational-tasks-test-aem-security.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-operational-tasks-test-aem-security.xml.j2
@@ -26,7 +26,7 @@
       <hudson.model.StringParameterDefinition>
         <name>AOC_CONFIG_PROFILE_AEM_TEST_SUITE</name>
         <description>Name of the AEM Test Suite configuration profile.</description>
-        <defaultValue>{{ item[0].item.path }}</defaultValue>
+        <defaultValue>{{ item[2].item.path }}</defaultValue>
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
@@ -44,7 +44,7 @@
       <hudson.model.StringParameterDefinition>
         <name>AOC_CONFIG_PROFILE_AEM_STACK_MANAGER_MESSENGER</name>
         <description>Name of the AEM Stack Manager Messenger configuration profile.</description>
-        <defaultValue>{{ item[0].item.path }}</defaultValue>
+        <defaultValue>{{ item[1] }}</defaultValue>
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
@@ -91,7 +91,7 @@
       <submoduleCfg class="list"/>
       <extensions/>
     </scm>
-    <scriptPath>provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/{{ item[1] }}/</scriptPath>
+    <scriptPath>provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/{{ item[0].item.path }}/</scriptPath>
     <lightweight>true</lightweight>
   </definition>
   <triggers/>

--- a/templates/ansible/jenkins/config/jobs-operational-tasks-test-architecture-type.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-operational-tasks-test-architecture-type.xml.j2
@@ -24,7 +24,7 @@
       <hudson.model.StringParameterDefinition>
         <name>AOC_CONFIG_PROFILE_AEM_TEST_SUITE</name>
         <description>Name of the AEM Test Suite configuration profile.</description>
-        <defaultValue>{{ item[0].item.path }}</defaultValue>
+        <defaultValue>{{ item[2].item.path }}</defaultValue>
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
@@ -42,7 +42,7 @@
       <hudson.model.StringParameterDefinition>
         <name>AOC_CONFIG_PROFILE_AEM_STACK_MANAGER_MESSENGER</name>
         <description>Name of the AEM Stack Manager Messenger configuration profile.</description>
-        <defaultValue>{{ item[0].item.path }}</defaultValue>
+        <defaultValue>{{ item[1] }}</defaultValue>
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
@@ -89,7 +89,7 @@
       <submoduleCfg class="list"/>
       <extensions/>
     </scm>
-    <scriptPath>provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/{{ item[1] }}/</scriptPath>
+    <scriptPath>provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/{{ item[0].item.path }}/</scriptPath>
     <lightweight>true</lightweight>
   </definition>
   <triggers/>

--- a/templates/ansible/jenkins/config/jobs-operational-tasks-test-recovery.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-operational-tasks-test-recovery.xml.j2
@@ -25,7 +25,7 @@
       <hudson.model.StringParameterDefinition>
         <name>AOC_CONFIG_PROFILE_AEM_TEST_SUITE</name>
         <description>Name of the AEM Test Suite configuration profile.</description>
-        <defaultValue>{{ item[0].item.path }}</defaultValue>
+        <defaultValue>{{ item[2].item.path }}</defaultValue>
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
@@ -43,7 +43,7 @@
       <hudson.model.StringParameterDefinition>
         <name>AOC_CONFIG_PROFILE_AEM_STACK_MANAGER_MESSENGER</name>
         <description>Name of the AEM Stack Manager Messenger configuration profile.</description>
-        <defaultValue>{{ item[0].item.path }}</defaultValue>
+        <defaultValue>{{ item[1] }}</defaultValue>
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
@@ -90,7 +90,7 @@
       <submoduleCfg class="list"/>
       <extensions/>
     </scm>
-    <scriptPath>provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/{{ item[1] }}/</scriptPath>
+    <scriptPath>provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/{{ item[0].item.path }}/</scriptPath>
     <lightweight>true</lightweight>
   </definition>
   <triggers/>

--- a/templates/ansible/jenkins/config/jobs-operational-tasks-test.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-operational-tasks-test.xml.j2
@@ -15,7 +15,7 @@
       <hudson.model.StringParameterDefinition>
         <name>AOC_CONFIG_PROFILE_AEM_TEST_SUITE</name>
         <description>Name of the AEM Test Suite configuration profile.</description>
-        <defaultValue>{{ item[0].item.path }}</defaultValue>
+        <defaultValue>{{ item[2].item.path }}</defaultValue>
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
@@ -33,7 +33,7 @@
       <hudson.model.StringParameterDefinition>
         <name>AOC_CONFIG_PROFILE_AEM_STACK_MANAGER_MESSENGER</name>
         <description>Name of the AEM Stack Manager Messenger configuration profile.</description>
-        <defaultValue>{{ item[0].item.path }}</defaultValue>
+        <defaultValue>{{ item[1] }}</defaultValue>
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
@@ -80,7 +80,7 @@
       <submoduleCfg class="list"/>
       <extensions/>
     </scm>
-    <scriptPath>provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/{{ item[1] }}/</scriptPath>
+    <scriptPath>provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/{{ item[0].item.path }}/</scriptPath>
     <lightweight>true</lightweight>
   </definition>
   <triggers/>


### PR DESCRIPTION
* Fix error where more than one aem test suite configuration profile 
exists
* Updated operational test tasks path to e.g. 
operational-tasks/stack-manager-messenger-profile-name/test-aem-security/aem-test-suite-profile-name/