### PR TITLE
#58 Added new paramter to disable removal of the AEM Stack prerequisites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Added new paramter to disable removal of the AEM Stack prerequisites #58
+
 ### Changed
 - Upgrade AEM Stack Manager Messenger to 2.9.0
 - Upgrade AEM Test Suite to 1.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- Added new paramter to disable removal of the AEM Stack prerequisites #58
+- Added new build parameter REMOVE_PREREQUISITES to disable removal of the AEM Stack prerequisites for delete Full-Set and Consolidated #58
 
 ### Changed
 - Upgrade AEM Stack Manager Messenger to 2.9.0

--- a/provisioners/ansible/playbooks/includes/manage-environments-gen.yaml
+++ b/provisioners/ansible/playbooks/includes/manage-environments-gen.yaml
@@ -17,18 +17,34 @@
 - name: Create a list of AEM Consolidated manage environments jobs for AWS
   shell: echo {{ item.path }}
   with_filetree: ../../../provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/
-  when: item.state == 'file' and ( item.path is match('create-consolidated') or item.path is match('delete-consolidated') )
+  when: item.state == 'file' and item.path is match('create-consolidated')
   register: manage_environments_aem_consolidated_jobs
+
+- name: Create a list of AEM Consolidated manage environments deletion jobs for AWS
+  shell: echo {{ item.path }}
+  with_filetree: ../../../provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/
+  when: item.state == 'file' and item.path is match('delete-consolidated')
+  register: manage_environments_delete_aem_consolidated_jobs
 
 - name: Trim skipped AEM Consolidated manage environments jobs for AWS
   set_fact:
     manage_environments_aem_consolidated_jobs_trimmed: "{{ manage_environments_aem_consolidated_jobs | trim_skipped() }}"
 
+- name: Trim skipped AEM Consolidated manage environments deletion jobs for AWS
+  set_fact:
+    manage_environments_delete_aem_consolidated_jobs_trimmed: "{{ manage_environments_delete_aem_consolidated_jobs | trim_skipped() }}"
+
 - name: Create a list of AEM Full-Set manage environments jobs for AWS
   shell: echo {{ item.path }}
   with_filetree: ../../../provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/
-  when: item.state == 'file' and ( item.path is match('create-full-set') or item.path is match('delete-full-set'))
+  when: item.state == 'file' and item.path is match('create-full-set')
   register: manage_environments_aem_full_set_jobs
+
+- name: Create a list of AEM Full-Set manage environments deletion jobs for AWS
+  shell: echo {{ item.path }}
+  with_filetree: ../../../provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/
+  when: item.state == 'file' and item.path is match('delete-full-set')
+  register: manage_environments_delete_aem_full_set_jobs
 
 - name: Create a list of AEM Consolidated-Switch-DNS manage environments job for AWS
   shell: echo {{ item.path }}
@@ -54,6 +70,10 @@
   set_fact:
     manage_environments_aem_full_set_jobs_trimmed: "{{ manage_environments_aem_full_set_jobs | trim_skipped() }}"
 
+- name: Trim skipped AEM Full-Set manage environments deletion jobs for AWS
+  set_fact:
+    manage_environments_delete_aem_full_set_jobs_trimmed: "{{ manage_environments_delete_aem_full_set_jobs | trim_skipped() }}"
+
 - name: "Generate jobs for AEM Stack Manager manage environments configuration profile directories"
   file:
     path: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/manage-environments/aws/{{ item[0].item.path }}/{{ item[1].item.path }}/
@@ -71,6 +91,17 @@
   with_nested:
     - "{{ aem_aws_stack_builder_aem_consolidated_profiles_trimmed.results }}"
     - "{{ manage_environments_aem_consolidated_jobs_trimmed.results }}"
+    - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
+    - "{{ aem_test_suite_profiles_trimmed.results }}"
+
+- name: "Generate jobs for AEM Consolidated manage environments deletion configuration profile directories"
+  file:
+    path: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/manage-environments/aws/{{ item[0].item.path }}-{{ item[2].item.path }}-{{ item[3].item.path }}/{{ item[1].item.path }}/
+    state: directory
+    mode: '0776'
+  with_nested:
+    - "{{ aem_aws_stack_builder_aem_consolidated_profiles_trimmed.results }}"
+    - "{{ manage_environments_delete_aem_consolidated_jobs_trimmed.results }}"
     - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
     - "{{ aem_test_suite_profiles_trimmed.results }}"
 
@@ -96,6 +127,16 @@
     - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
     - "{{ aem_test_suite_profiles_trimmed.results }}"
 
+- name: "Generate jobs for AEM Full-Set manage environments deletion configuration profile directories"
+  file:
+    path: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/manage-environments/aws/{{ item[0].item.path }}-{{ item[2].item.path }}-{{ item[3].item.path }}/{{ item[1].item.path }}/
+    state: directory
+    mode: '0776'
+  with_nested:
+    - "{{ aem_aws_stack_builder_aem_full_set_profiles_trimmed.results }}"
+    - "{{ manage_environments_delete_aem_full_set_jobs_trimmed.results }}"
+    - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
+    - "{{ aem_test_suite_profiles_trimmed.results }}"
 
 - name: "Generate jobs for AEM Full-Set manage environments configuration profile directories"
   file:
@@ -128,6 +169,17 @@
     - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
     - "{{ aem_test_suite_profiles_trimmed.results }}"
 
+- name: "Generate jobs for AEM Consolidated configuration profile config.xml for manage-environments deletion configuration profile components"
+  template:
+    src: '../../../templates/ansible/jenkins/config/category-config-profile.xml.j2'
+    dest: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/manage-environments/aws/{{ item[0].item.path }}-{{ item[2].item.path }}-{{ item[3].item.path }}/config.xml
+    mode: '0644'
+  with_nested:
+    - "{{ aem_aws_stack_builder_aem_consolidated_profiles_trimmed.results }}"
+    - "{{ manage_environments_delete_aem_consolidated_jobs_trimmed.results }}"
+    - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
+    - "{{ aem_test_suite_profiles_trimmed.results }}"
+
 - name: "Generate jobs for AEM Switch-DNS-Consolidated configuration profile config.xml for manage-environments configuration profile components"
   template:
     src: '../../../templates/ansible/jenkins/config/category-config-profile.xml.j2'
@@ -147,6 +199,17 @@
   with_nested:
     - "{{ aem_aws_stack_builder_aem_full_set_profiles_trimmed.results }}"
     - "{{ manage_environments_aem_full_set_jobs_trimmed.results }}"
+    - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
+    - "{{ aem_test_suite_profiles_trimmed.results }}"
+
+- name: "Generate jobs for AEM Full-Set configuration profile config.xml for manage-environments deletion configuration profile components"
+  template:
+    src: '../../../templates/ansible/jenkins/config/category-config-profile.xml.j2'
+    dest: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/manage-environments/aws/{{ item[0].item.path }}-{{ item[2].item.path }}-{{ item[3].item.path }}/config.xml
+    mode: '0644'
+  with_nested:
+    - "{{ aem_aws_stack_builder_aem_full_set_profiles_trimmed.results }}"
+    - "{{ manage_environments_delete_aem_full_set_jobs_trimmed.results }}"
     - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
     - "{{ aem_test_suite_profiles_trimmed.results }}"
 
@@ -183,6 +246,19 @@
     - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
     - "{{ aem_test_suite_profiles_trimmed.results }}"
 
+- name: "Generate jobs for AEM Consolidated config.xml for manage-environments deletion configuration profile components"
+  vars:
+    aem_architecture_type: consolidated
+  template:
+    src: ../../../templates/ansible/jenkins/config/jobs-manage-environments-aem-delete.xml.j2
+    dest: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/manage-environments/aws/{{ item[0].item.path }}-{{ item[2].item.path }}-{{ item[3].item.path }}/{{ item[1].item.path }}/config.xml
+    mode: '0644'
+  with_nested:
+    - "{{ aem_aws_stack_builder_aem_consolidated_profiles_trimmed.results }}"
+    - "{{ manage_environments_delete_aem_consolidated_jobs_trimmed.results }}"
+    - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
+    - "{{ aem_test_suite_profiles_trimmed.results }}"
+
 - name: "Generate jobs for AEM Full-Set config.xml for manage-environments configuration profile components"
   vars:
     aem_architecture_type: full-set
@@ -193,6 +269,19 @@
   with_nested:
     - "{{ aem_aws_stack_builder_aem_full_set_profiles_trimmed.results }}"
     - "{{ manage_environments_aem_full_set_jobs_trimmed.results }}"
+    - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
+    - "{{ aem_test_suite_profiles_trimmed.results }}"
+
+- name: "Generate jobs for AEM Full-Set config.xml for manage-environments deletion configuration profile components"
+  vars:
+    aem_architecture_type: full-set
+  template:
+    src: ../../../templates/ansible/jenkins/config/jobs-manage-environments-aem.xml.j2
+    dest: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/manage-environments/aws/{{ item[0].item.path }}-{{ item[2].item.path }}-{{ item[3].item.path }}/{{ item[1].item.path }}/config.xml
+    mode: '0644'
+  with_nested:
+    - "{{ aem_aws_stack_builder_aem_full_set_profiles_trimmed.results }}"
+    - "{{ manage_environments_delete_aem_full_set_jobs_trimmed.results }}"
     - "{{ aem_stack_manager_messenger_profiles_trimmed.results }}"
     - "{{ aem_test_suite_profiles_trimmed.results }}"
 

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/delete-consolidated
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/delete-consolidated
@@ -64,8 +64,14 @@ pipeline {
         stage('Delete AEM OpenCloud Consolidated environment') {
             steps {
                     JenkinsStagePreStep this
+                    script {
+                        if (params.REMOVE_PREREQUISITES) {
+                          ExecCommand(this, env.TMPDIR, "aem-aws-stack-builder", "make delete-consolidated config_path=${env.AOC_CONFIG_DIR}/aem-aws-stack-builder/${params.AOC_CONFIG_PROFILE_AEM_AWS_STACK_BUILDER}/ stack_prefix=${params.STACK_PREFIX}")
+                        } else {
+                          ExecCommand(this, env.TMPDIR, "aem-aws-stack-builder", "make delete-consolidated-main config_path=${env.AOC_CONFIG_DIR}/aem-aws-stack-builder/${params.AOC_CONFIG_PROFILE_AEM_AWS_STACK_BUILDER}/ stack_prefix=${params.STACK_PREFIX}")
+                      }
+                  }
 
-                    ExecCommand(this, env.TMPDIR, "aem-aws-stack-builder", "make delete-consolidated config_path=${env.AOC_CONFIG_DIR}/aem-aws-stack-builder/${params.AOC_CONFIG_PROFILE_AEM_AWS_STACK_BUILDER}/ stack_prefix=${params.STACK_PREFIX}")
             }
             post {
                 always {

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/delete-full-set
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/delete-full-set
@@ -64,8 +64,13 @@ pipeline {
         stage('Delete AEM OpenCloud Full-Set environment') {
             steps {
                     JenkinsStagePreStep this
-
-                    ExecCommand(this, env.TMPDIR, "aem-aws-stack-builder", "make delete-full-set config_path=${env.AOC_CONFIG_DIR}/aem-aws-stack-builder/${params.AOC_CONFIG_PROFILE_AEM_AWS_STACK_BUILDER}/ stack_prefix=${params.STACK_PREFIX}")
+                    script {
+                        if (params.REMOVE_PREREQUISITES) {
+                          ExecCommand(this, env.TMPDIR, "aem-aws-stack-builder", "make delete-full-set config_path=${env.AOC_CONFIG_DIR}/aem-aws-stack-builder/${params.AOC_CONFIG_PROFILE_AEM_AWS_STACK_BUILDER}/ stack_prefix=${params.STACK_PREFIX}")
+                        } else {
+                          ExecCommand(this, env.TMPDIR, "aem-aws-stack-builder", "make delete-full-set-main config_path=${env.AOC_CONFIG_DIR}/aem-aws-stack-builder/${params.AOC_CONFIG_PROFILE_AEM_AWS_STACK_BUILDER}/ stack_prefix=${params.STACK_PREFIX}")
+                        }
+                    }
             }
             post {
                 always {

--- a/templates/ansible/jenkins/config/jobs-manage-environments-aem-delete.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-manage-environments-aem-delete.xml.j2
@@ -1,0 +1,94 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<flow-definition plugin="workflow-job@2.31">
+  <actions/>
+  <description>AEM OpenCloud Jenkins job provisioned with AEM OpenCloud Manager.</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+  <hudson.model.ParametersDefinitionProperty>
+    <parameterDefinitions>
+      <hudson.model.BooleanParameterDefinition>
+        <name>ENABLE_SLACK_NOTIFICATIONS</name>
+        <description>If activated SLACK notifications will be send out.</description>
+        <defaultValue>{{ aem_opencloud.enable_slack_notifications }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.BooleanParameterDefinition>
+      <hudson.model.StringParameterDefinition>
+        <name>STACK_PREFIX</name>
+        <description>AEM OpenCloud AEM stack prefix.</description>
+        <defaultValue></defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.BooleanParameterDefinition>
+        <name>REMOVE_PREREQUISITES</name>
+        <description>Enable/disable the removal of the AEM pre-requisite stack.</description>
+        <defaultValue>true</defaultValue>
+        <trim>true</trim>
+      </hudson.model.BooleanParameterDefinition>
+      <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_DOCKER_IMAGE</name>
+        <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
+        <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_DOCKER_ARGS</name>
+        <description>The CLI args for Jenkins to use when running Docker CLI.</description>
+        <defaultValue>{{ jenkins.agent.docker_args }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
+        <name>AOC_CONFIG_PROFILE_AEM_AWS_STACK_BUILDER</name>
+        <description>Name of the AEM AWS Stack Builder configuration profile.</description>
+        <defaultValue>{{ item[0].item.path }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
+        <name>AOC_CONFIG_ARTIFACT_URL</name>
+        <description>URL to the AEM OpenCloud Configuration artifact.</description>
+        <defaultValue>{{ aem_opencloud.config.artifact_url }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
+        <name>AOC_CUSTOM_MANAGER_STEPS_ARTIFACT_URL</name>
+        <description>URL to the AEM OpenCloud Manager custom manager steps artifact.</description>
+        <defaultValue>{{ aem_opencloud.custom_manager_steps.artifact_url }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
+        <name>AWS_LIBRARY_S3_BUCKET</name>
+        <description>S3 bucket where the libraries are stored</description>
+        <defaultValue>{{ aws.library.s3_bucket }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
+        <name>AWS_LIBRARY_S3_PATH</name>
+        <description>S3 path (of the specified S3 bucket) where the libraries are stored</description>
+        <defaultValue>{{ aws.library.s3_path }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+    </parameterDefinitions>
+  </hudson.model.ParametersDefinitionProperty>
+</properties>
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps@2.61">
+    <scm class="hudson.plugins.git.GitSCM" plugin="git@3.9.1">
+      <configVersion>2</configVersion>
+      <userRemoteConfigs>
+        <hudson.plugins.git.UserRemoteConfig>
+          <url>{{ aem_opencloud.jenkins_sharedlibs.repo_url }}</url>
+        </hudson.plugins.git.UserRemoteConfig>
+      </userRemoteConfigs>
+      <branches>
+        <hudson.plugins.git.BranchSpec>
+          <name>{{ aem_opencloud.jenkins_sharedlibs.repo_branch }}</name>
+        </hudson.plugins.git.BranchSpec>
+      </branches>
+      <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+      <submoduleCfg class="list"/>
+      <extensions/>
+    </scm>
+    <scriptPath>provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/{{ item[1].item.path }}/</scriptPath>
+    <lightweight>true</lightweight>
+  </definition>
+  <triggers/>
+  <disabled>false</disabled>
+</flow-definition>


### PR DESCRIPTION
Added new paramter to disable removal of the AEM Stack prerequisites #58

This PR adds a new paramter to the AEM Full-Set & Consolidates deletion which allows the user to skip the removal of the prerequisites stack. 

The default value remains the same, as to always delete the prerequisites stack.