### PR TITLE
Add new utility pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Add new Jenkins Job category `utilities` for general utility jobs
+- Add utility pipeline `encrypt-snapshots` for encrypting OpenCloud Snapshots on AWS
+
 ## [4.2.0-pre.2] - 2010-01-21
 
 ### Changed

--- a/provisioners/ansible/playbooks/includes/utilities-gen.yaml
+++ b/provisioners/ansible/playbooks/includes/utilities-gen.yaml
@@ -1,0 +1,31 @@
+---
+
+########################################################################
+# Generate testing Jenkins jobs.
+########################################################################
+
+- name: Create a list of utility jobs for AWS
+  shell: echo {{ item.path }}
+  with_filetree: ../../../provisioners/jenkins/jenkinsfiles/aem-opencloud/utilities/aws/
+  when: item.state == 'file'
+  register: utilities_jobs
+
+- name: Trim utility jobs for AWS
+  set_fact:
+    utilities_jobs_trimmed: "{{ utilities_jobs | trim_skipped() }}"
+
+- name: "Generate utility aws snapshots encryption jobs directories"
+  file:
+    path: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/utilities/aws/{{ item.item.path }}
+    state: directory
+    mode: '0776'
+  with_items:
+    - "{{ utilities_jobs_trimmed.results }}"
+
+- name: "Generate jobs for utility aws snapshots encryption config.xml"
+  template:
+    src: '../../../templates/ansible/jenkins/config/jobs-utilities-encrypt-aws-snapshots.xml.j2'
+    dest: ../../../stage/jenkins/jobs/aem-opencloud-{{ aem_opencloud.version }}/utilities/aws/{{ item.item.path }}/config.xml
+    mode: '0644'
+  with_items:
+    - "{{ utilities_jobs_trimmed.results }}"

--- a/provisioners/ansible/playbooks/jenkins-aws-gen.yaml
+++ b/provisioners/ansible/playbooks/jenkins-aws-gen.yaml
@@ -266,3 +266,5 @@
     - import_tasks: includes/migration-gen.yaml
 
     - import_tasks: includes/testing-gen.yaml
+
+    - import_tasks: includes/utilities-gen.yaml

--- a/provisioners/ansible/playbooks/jenkins/encrypt-unencrypted-aws-snapshots.yaml
+++ b/provisioners/ansible/playbooks/jenkins/encrypt-unencrypted-aws-snapshots.yaml
@@ -1,0 +1,131 @@
+---
+# This playbook gets excluvely executed by the AEM OpenCloud Manager pipeline encrypt-aws-snapshots
+# And will encrypt unencrypted AEM OpenCloud Snapshots
+
+- name: Encrypt not encrypted Snapshots via Tag SnapshotType or provided comma seperated list of Snapshot IDs
+  hosts: all
+  gather_facts: false
+  connection: local
+  vars:
+    # snapshot_list is used to save all found unencrypted snapshots
+    snapshot_list: []
+    # encrypted_snapshot_ids_list is used to save all
+    # returned encrypted snapshot ids
+    encrypted_snapshot_ids_list: []
+    # unencrypted_and_encrypted_snapshot_ids_list is used to save all
+    # returned encrypted snapshot ids to it's unencrypted parent
+    # so we can verify if a snapshot copy error occured
+    unencrypted_and_encrypted_snapshot_ids_list: []
+
+  tasks:
+  - name: "Gather Snapshots by provided snapshot-ids"
+    ec2_snapshot_info:
+      snapshot_ids: "{{ snapshot_ids.split(',') }}"
+    when: (snapshot_ids is defined and snapshot_ids != '') or
+          (snapshot_ids is defined and snapshot_ids != '') or
+          (snapshot_ids is defined and snapshot_ids != '')
+    register: found_snapshot_ids
+
+  - name: "Gather Snapshots by Snapshot Type {{ snapshot_type }}"
+    ec2_snapshot_info:
+      filters:
+        "tag:SnapshotType": "{{ snapshot_type }}"
+    when: (snapshot_type is defined and snapshot_type != '' and snapshot_ids is undefined) or
+          (snapshot_type is defined and snapshot_type != '' and snapshot_ids == '') or
+          (snapshot_type is defined and snapshot_type != '' and not snapshot_ids)
+    register: found_offline_snapshot_ids
+
+  - name: "Add unencrypted Snapshots provided via snapshot-ids to list of found snapshots"
+    set_fact:
+      snapshot_list: "{{ snapshot_list + [item] }}"
+    when: found_snapshot_ids.snapshots is defined and (found_snapshot_ids.snapshots | length > 0) and item.state == 'completed' and not item.encrypted
+    with_items:
+      - "{{ found_snapshot_ids.snapshots }}"
+
+  - name: "Add unencrypted provided via snapshot-type to list of found snapshots"
+    set_fact:
+      snapshot_list: "{{ snapshot_list + [item] }}"
+    when: found_offline_snapshot_ids.snapshots is defined and (found_offline_snapshot_ids.snapshots | length > 0) and item.state == 'completed' and not item.encrypted
+    with_items:
+      - "{{ found_offline_snapshot_ids.snapshots }}"
+
+  # We are sorting all found Snapshot IDs from the oldest to the most
+  # recent ones so the snapshot are encrypted in the historical correct order
+  # to avoid confusions how old whhich snapshot is
+  - name: "Sort found snapshots from oldest to most recent ones"
+    set_fact:
+      snapshot_list: "{{ snapshot_list | sort(attribute='start_time') }}"
+    when: snapshot_list is defined and (snapshot_list | length > 0)
+
+  - name: "Encrypt snapshots"
+    ec2_snapshot_copy:
+      source_region: "{{ source_aws_region }}"
+      source_snapshot_id: "{{ item.snapshot_id }}"
+      description: "{{ item.description }}"
+      tags: "{{ item.tags }}"
+      encrypted: yes
+      kms_key_id: "{{ kms_key_id }}"
+      wait: true
+      wait_timeout: "{{ wait_time }}"
+    when: snapshot_list is defined and (snapshot_list | length > 0)
+    register: encrypted_snapshots
+    with_items:
+      - "{{ snapshot_list }}"
+
+    # We setup a list based on the results we got when we encrypted the AWS Snapshots
+    # The result contains the unencrypted snapshot id and the encrypted snapshot id
+    # for each snapshot we are encrypting. Therefore we are saving both to verify if
+    # the encryption was successful
+  - name: "Save new Snapshot IDs for validation"
+    set_fact:
+      unencrypted_and_encrypted_snapshot_ids_list: "{{ unencrypted_and_encrypted_snapshot_ids_list + [{'unencrypted_snapshot_id': item.item.snapshot_id, 'encrypted_snapshot_id': item.snapshot_id}] }}"
+    when: snapshot_list is defined and (snapshot_list | length > 0)
+    with_items:
+      - "{{ encrypted_snapshots.results }}"
+
+  - name: "Gather information of encrypted snapshots for validation"
+    ec2_snapshot_info:
+      snapshot_ids: "{{ unencrypted_and_encrypted_snapshot_ids_list | map(attribute='encrypted_snapshot_id') | list }}"
+    when: snapshot_list is defined and (snapshot_list | length > 0)
+    register: encrypted_snapshot_facts
+
+  - name: "Fail if no encrypted snapshots were found for validation"
+    fail:
+      msg: |
+        ERROR: No Snapshots for validation were found
+
+        Debug message:
+          {{ encrypted_snapshot_facts }}
+    when: (snapshot_list is defined and (snapshot_list | length > 0) and encrypted_snapshot_facts is undefined) or
+          (snapshot_list is defined and (snapshot_list | length > 0) and encrypted_snapshot_facts.snapshots is undefined)
+
+  #
+  # To make sure that we don't delete any unencrypted snapshots which
+  # were not encrypted or were the encryption resulted in an error
+  # we are failing the playbook.
+  - name: "Fail if encrypted snapshot is not encrypted or has errors"
+    fail:
+      msg: |
+        ERRROR: Error while encrypting Snapshots.
+
+        Unencrypted Snapshot-id: {{ unencrypted_and_encrypted_snapshot_ids_list | selectattr('encrypted_snapshot_id', 'equalto', item.snapshot_id) | map(attribute='unencrypted_snapshot_id') }}
+
+        Encrypted Snapshot-id: {{ item.snapshot_id }}
+
+        Debug message:
+
+    when: (snapshot_list is defined and (snapshot_list | length > 0) and not item.encrypted) or
+          (snapshot_list is defined and (snapshot_list | length > 0) and item.state == 'error')
+    with_items:
+      - "{{ encrypted_snapshot_facts.snapshots }}"
+
+  - name: "Remove unencrypted encrypted snapshots by Snapshot Type {{ snapshot_type }}"
+    ec2_snapshot:
+      region: "{{ source_aws_region }}"
+      snapshot_id: "{{ item.unencrypted_snapshot_id }}"
+      state: absent
+      wait: true
+      wait_timeout: "{{ wait_time }}"
+    when: (remove_unencrypted | bool  and (item | length > 0) and item.unencrypted_snapshot_id is defined)
+    with_items:
+      - "{{ unencrypted_and_encrypted_snapshot_ids_list }}"

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/utilities/aws/encrypt-snapshots
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/utilities/aws/encrypt-snapshots
@@ -1,0 +1,68 @@
+@Library('aem-opencloud-manager') _
+def configString = libraryResource 'aem_opencloud/config.json'
+def config = readJSON text: configString
+pipeline {
+    agent {
+        docker {
+            image params.JENKINS_AGENT_DOCKER_IMAGE
+            args params.JENKINS_AGENT_DOCKER_ARGS
+        }
+    }
+    environment {
+        TMPDIR = "/tmp/shinesolutions/aem-opencloud-manager"
+        JENKINS_ANSIBLE_INVENTORY = "${WORKSPACE}/conf/ansible/inventory/hosts"
+        ANSIBLE_PLAYBOOK_PATH = "${WORKSPACE}/provisioners/ansible/playbooks/jenkins"
+    }
+    stages {
+        stage('Initialise pipeline') {
+            steps {
+                script {
+                    if (params.ENABLE_SLACK_NOTIFICATIONS == true) {
+                        slackSend (color: '#FFFF00', message: "START: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+                    }
+                }
+                JenkinsInit(this, params.AOC_CUSTOM_MANAGER_STEPS_ARTIFACT_URL, env.TMPDIR)
+                JenkinsPipelinePreStep this
+            }
+        }
+        stage('Encrypt AWS AEM OpenCloud Snapshots') {
+            steps {
+                    JenkinsStagePreStep this
+                    ansiblePlaybook inventory: env.JENKINS_ANSIBLE_INVENTORY,
+                      playbook: "${env.ANSIBLE_PLAYBOOK_PATH}/encrypt-unencrypted-aws-snapshots.yaml",
+                      extraVars: [
+                        snapshot_type: params.SNAPSHOT_TYPE,
+                        snapshot_ids: params.SNAPSHOT_IDS,
+                        kms_key_id: params.KMS_KEY_ID,
+                        wait_time: params.WAIT_TIME,
+                        remove_unencrypted: params.REMOVE_UNENCRYPTED,
+                        source_aws_region: params.SOURCE_AWS_REGION
+                      ]
+            }
+            post {
+                always {
+                  JenkinsStagePostStep this
+                }
+            }
+        }
+    }
+    post {
+        always {
+          JenkinsPipelinePostStep this
+        }
+        success {
+          script {
+            if (params.ENABLE_SLACK_NOTIFICATIONS == true) {
+                slackSend (color: '#00FF00', message: "SUCCESS: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+            }
+          }
+        }
+        failure {
+          script {
+            if (params.ENABLE_SLACK_NOTIFICATIONS == true) {
+                slackSend (color: '#FF0000', message: "FAILURE: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+            }
+          }
+        }
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 ansible==2.9.2
 ansible-lint==4.2.0
+boto==2.49.0
 boto3==1.10.41
 lxml===4.4.2
 python-jenkins==1.6.0

--- a/templates/ansible/jenkins/config/jobs-utilities-encrypt-aws-snapshots.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-utilities-encrypt-aws-snapshots.xml.j2
@@ -1,0 +1,101 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<flow-definition plugin="workflow-job@2.31">
+  <actions/>
+  <description>AEM OpenCloud Jenkins job provisioned with AEM OpenCloud Manager.</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+  <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty/>
+  <hudson.model.ParametersDefinitionProperty>
+    <parameterDefinitions>
+      <hudson.model.ChoiceParameterDefinition>
+        <name>SNAPSHOT_TYPE</name>
+        <description>(conditional) Encrypt snapshots based on the Snapshot Tag 'SnapshotType'. Only works when parameter SNAPSHOT_ID is empty.</description>
+        <defaultValue>offline</defaultValue>
+        <choices class="java.util.Arrays$ArrayList">
+          <a class="string-array">
+            <string>offline</string>
+            <string>live</string>
+            <string>orchestration</string>
+          </a>
+        </choices>
+      </hudson.model.ChoiceParameterDefinition>
+      <hudson.model.StringParameterDefinition>
+        <name>SNAPSHOT_IDS</name>
+        <description>(conditional) Comma seperated list of snapshots to encrypt.</description>
+        <defaultValue></defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
+        <name>KMS_KEY_ID</name>
+        <description>(optional) KMS Key ID to encrypt the new snapshots with. If no KMS Key ID is provided the default AWS KMS key is usedn instead.</description>
+        <defaultValue></defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
+        <name>SOURCE_AWS_REGION</name>
+        <description>(optional) Source AWS Region of the EC2 snapshots.</description>
+        <defaultValue>ap-southeast-2</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.BooleanParameterDefinition>
+        <name>REMOVE_UNENCRYPTED</name>
+        <description>(optional) If activated Unencrypted Snapshots will be removed after they were successfully encrypted.</description>
+        <defaultValue>true</defaultValue>
+        <trim>true</trim>
+      </hudson.model.BooleanParameterDefinition>
+      <hudson.model.StringParameterDefinition>
+        <name>WAIT_TIME</name>
+        <description>(optional) Wait time in seconds until the EC2 Snapshot copy process times out.</description>
+        <defaultValue>3600</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.BooleanParameterDefinition>
+        <name>ENABLE_SLACK_NOTIFICATIONS</name>
+        <description>(optional) If activated SLACK notifications will be send out.</description>
+        <defaultValue>{{ aem_opencloud.enable_slack_notifications }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.BooleanParameterDefinition>
+      <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_DOCKER_IMAGE</name>
+        <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
+        <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_DOCKER_ARGS</name>
+        <description>The CLI args for Jenkins to use when running Docker CLI.</description>
+        <defaultValue>{{ jenkins.agent.docker_args }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
+        <name>AOC_CUSTOM_MANAGER_STEPS_ARTIFACT_URL</name>
+        <description>URL to the AEM OpenCloud Manager custom manager steps artifact.</description>
+        <defaultValue>{{ aem_opencloud.custom_manager_steps.artifact_url }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+    </parameterDefinitions>
+  </hudson.model.ParametersDefinitionProperty>
+</properties>
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps@2.61">
+    <scm class="hudson.plugins.git.GitSCM" plugin="git@3.9.1">
+      <configVersion>2</configVersion>
+      <userRemoteConfigs>
+        <hudson.plugins.git.UserRemoteConfig>
+          <url>{{ aem_opencloud.jenkins_sharedlibs.repo_url }}</url>
+        </hudson.plugins.git.UserRemoteConfig>
+      </userRemoteConfigs>
+      <branches>
+        <hudson.plugins.git.BranchSpec>
+          <name>{{ aem_opencloud.jenkins_sharedlibs.repo_branch }}</name>
+        </hudson.plugins.git.BranchSpec>
+      </branches>
+      <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+      <submoduleCfg class="list"/>
+      <extensions/>
+    </scm>
+    <scriptPath>provisioners/jenkins/jenkinsfiles/aem-opencloud/utilities/aws/{{ item.item.path }}/</scriptPath>
+    <lightweight>true</lightweight>
+  </definition>
+  <triggers/>
+  <disabled>false</disabled>
+</flow-definition>


### PR DESCRIPTION
This PR will add a new pipeline called ```encrypt-snapshots``` and adds a new Job Category called ```utilities```. This catgeroy will contain utility jobs which are most likeley one-time jobs e.g. encrypting unencrypted AEM OpenCloud Snapshots.

The new pipeline will execute an Ansible playbook which will encrypt unencrypted snapshots based on a ```comma seperated list of snapshot-ids``` or via the tag SnapsotType ```offline,live or orchestration```. 

*Concurrent builds are disabled for this pipeline.*

The process of the encryption playbook is as follows:

* If Snapshot IDs are provided retrieve all snapshot facts
* If Snapshot Type is provided and no Snapshot IDs are provided retrieve all snapshot facts
* Generate a list of all found snapshots which are
** in the state `completed`
** not encrypted
* Sort the generated list from oldest found snapshot to the most recent one
This is to make sure that the most recent encrypted snapshot is the most recent unencrypted snapshot
* Encrypt snapshots from oldest to the most recent one and wait until snapshot encryption is done
Timeout is set to 1h. If necessary this can be increased via a Jenkins parameter
* Generate a list with a mapping of all encrypted snapshots whith their unencrypted parent for validation
* Retrieve all facts from the encrypted snapshots
* Fail if no encrypted snapshots were found for validation
* Fail if encrypted snapshot is not encrypted or has errors
* Remove all unencrypted snapshots if enabled

Jenkins Job parameters:
<img width="1101" alt="aws-snapshot-encryption-jenkins-params" src="https://user-images.githubusercontent.com/34461129/73506811-f4869f80-442a-11ea-90e2-813df3f5c2b2.png">


Jenkins Pipeline run:

<img width="950" alt="Screen Shot 2020-01-31 at 13 17 39" src="https://user-images.githubusercontent.com/34461129/73507127-12083900-442c-11ea-8d4f-3559c6166c03.png">

