### PR TITLE
Upgrade Jenkins agent Docker image to aem-platform-buildenv 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Upgrade default Jenkins agent Docker image to aem-platform-buildenv 1.7.0
 
 ## 4.9.0 - 2020-06-15
 ### Changed

--- a/conf/ansible/inventory/group_vars/defaults.yaml
+++ b/conf/ansible/inventory/group_vars/defaults.yaml
@@ -42,7 +42,7 @@ jenkins:
   username: overwrite-me
   password: overwrite-me
   agent:
-    docker_image: 'shinesolutions/aem-platform-buildenv:1.6.0'
+    docker_image: 'shinesolutions/aem-platform-buildenv:1.7.0'
     docker_args: ''
   os:
     jenkins_home: null


### PR DESCRIPTION
### Changed
- Upgrade default Jenkins agent Docker image to aem-platform-buildenv 1.7.0