### PR TITLE
Update python libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Update boto3 to 1.17.8
+- Update Ansible to 3.0.0
+- Update ansible-lint to 5.0.2
+- Update python-jenkins to 1.7.0
+
+### Removed
+- Removed python module lxml
 
 ## 5.1.0 - 2021-02-11
 ### Changed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-ansible==2.9.2
-ansible-lint==4.2.0
+ansible==3.0.0
+ansible-lint==5.0.2
 boto==2.49.0
 boto3==1.17.8
-lxml===4.6.2
-python-jenkins==1.6.0
+python-jenkins==1.7.0


### PR DESCRIPTION
Update python libraries
### Changed
- Update Ansible to 3.0.0
- Update ansible-lint to 5.0.2
- Update python-jenkins to 1.7.0

### Removed
- Removed python module lxml