### PR TITLE
Add jenkins_agent.label configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added new Pipeline to run security test for Full-Set & Consolidated
 - Added new parameter to operational task test-aem-security pipeline to inject AEM Host to test via input parameters
+- Add jenkins_agent.label configuration
 
 ### Changed
 - Reorganised Full-Set/Consolidated Platform Testing pipeline so they trigger the existing pipelines for the testing

--- a/conf/ansible/inventory/group_vars/defaults.yaml
+++ b/conf/ansible/inventory/group_vars/defaults.yaml
@@ -42,6 +42,7 @@ jenkins:
   username: overwrite-me
   password: overwrite-me
   agent:
+    label: ''
     docker_image: shinesolutions/aem-platform-buildenv:2.0.0
     docker_args: ''
   os:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,7 @@ The following configurations are available for users to customise:
 | jenkins.port | Port of the Jenkins server | Mandatory | `8080` |
 | jenkins.username | Jenkins username to create jobs. | Mandatory | |
 | jenkins.password | Jenkins user password. | Mandatory | |
+| jenkins.agent.label | Jenkins build agent label, leave empty is not needed | Optional | `` |
 | jenkins.agent.docker_image | Jenkins Docker agent image to use | Optional | `shinesolutions/aem-platform-buildenv:latest` |
 | jenkins.agent.docker_args | Additional Jenkins Docker agent CLI launch arguments | Optional | |
 | jenkins.os.jenkins_home | [Jenkins home](https://wiki.jenkins.io/display/JENKINS/Administering+Jenkins) directory. | Optional | |

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/installation/aws/create-aem-aws-stack-builder-resources
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/installation/aws/create-aem-aws-stack-builder-resources
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/installation/aws/create-packer-aem-resources
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/installation/aws/create-packer-aem-resources
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/installation/aws/delete-packer-aem-resources
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/installation/aws/delete-packer-aem-resources
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/installation/aws/delete-stack-builder-resources
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/installation/aws/delete-stack-builder-resources
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/installation/aws/mirror-aem-opencloud-libraries
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/installation/aws/mirror-aem-opencloud-libraries
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/installation/aws/mirror-stack-builder-libraries
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/installation/aws/mirror-stack-builder-libraries
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/machine-images/aws/author
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/machine-images/aws/author
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/machine-images/aws/author-publish-dispatcher
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/machine-images/aws/author-publish-dispatcher
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/machine-images/aws/dispatcher
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/machine-images/aws/dispatcher
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/machine-images/aws/java
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/machine-images/aws/java
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/machine-images/aws/publish
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/machine-images/aws/publish
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/create-consolidated
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/create-consolidated
@@ -4,6 +4,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/create-full-set
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/create-full-set
@@ -4,6 +4,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/create-stack-manager
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/create-stack-manager
@@ -4,6 +4,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/delete-consolidated
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/delete-consolidated
@@ -4,6 +4,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/delete-full-set
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/delete-full-set
@@ -4,6 +4,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/delete-stack-manager
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/delete-stack-manager
@@ -4,6 +4,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/switch-dns-consolidated
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/switch-dns-consolidated
@@ -4,6 +4,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/switch-dns-full-set
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/manage-environments/aws/switch-dns-full-set
@@ -4,6 +4,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/migration/aws/aem-reconfiguration
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/migration/aws/aem-reconfiguration
@@ -4,6 +4,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGEx
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/migration/aws/aem-upgrade-export-import
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/migration/aws/aem-upgrade-export-import
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/migration/aws/aem-upgrade-in-place
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/migration/aws/aem-upgrade-in-place
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/check-readiness-consolidated
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/check-readiness-consolidated
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/check-readiness-full-set
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/check-readiness-full-set
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/deploy-artifact
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/deploy-artifact
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/deploy-artifacts-consolidated
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/deploy-artifacts-consolidated
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/deploy-artifacts-full-set
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/deploy-artifacts-full-set
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/disable-crxde
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/disable-crxde
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/disable-saml
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/disable-saml
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/enable-crxde
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/enable-crxde
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/enable-saml
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/enable-saml
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/export-packages-consolidated
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/export-packages-consolidated
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/export-packages-full-set
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/export-packages-full-set
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/flush-dispatcher-cache
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/flush-dispatcher-cache
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/import-package
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/import-package
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/install-aem-profile
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/install-aem-profile
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/list-packages
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/list-packages
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/live-snapshot
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/live-snapshot
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/offline-compaction-snapshot-consolidated
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/offline-compaction-snapshot-consolidated
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/offline-compaction-snapshot-full-set
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/offline-compaction-snapshot-full-set
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/offline-snapshot-consolidated
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/offline-snapshot-consolidated
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/offline-snapshot-full-set
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/offline-snapshot-full-set
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/promote-author
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/promote-author
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/schedule-live-snapshot-consolidated
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/schedule-live-snapshot-consolidated
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/schedule-live-snapshot-full-set
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/schedule-live-snapshot-full-set
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/schedule-offline-compaction-snapshot-consolidated
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/schedule-offline-compaction-snapshot-consolidated
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/schedule-offline-compaction-snapshot-full-set
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/schedule-offline-compaction-snapshot-full-set
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/schedule-offline-snapshot-consolidated
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/schedule-offline-snapshot-consolidated
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/schedule-offline-snapshot-full-set
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/schedule-offline-snapshot-full-set
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/test-acceptance
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/test-acceptance
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/test-aem-security
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/test-aem-security
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/test-contenthealthcheck-alarm
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/test-contenthealthcheck-alarm
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/test-recovery
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/test-recovery
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/unschedule-live-snapshot-consolidated
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/unschedule-live-snapshot-consolidated
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/unschedule-live-snapshot-full-set
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/unschedule-live-snapshot-full-set
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/unschedule-offline-compaction-snapshot-consolidated
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/unschedule-offline-compaction-snapshot-consolidated
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/unschedule-offline-compaction-snapshot-full-set
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/unschedule-offline-compaction-snapshot-full-set
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/unschedule-offline-snapshot-consolidated
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/unschedule-offline-snapshot-consolidated
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/unschedule-offline-snapshot-full-set
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/operational-tasks/unschedule-offline-snapshot-full-set
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/testing/aws/consolidated-platform
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/testing/aws/consolidated-platform
@@ -12,7 +12,10 @@ def date = getDate()
 def id = genId()
 pipeline {
     agent {
-        docker {
+            docker {
+              if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/testing/aws/consolidated-security
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/testing/aws/consolidated-security
@@ -13,6 +13,9 @@ def id = genId()
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/testing/aws/full-set-blue-green
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/testing/aws/full-set-blue-green
@@ -13,6 +13,9 @@ def id = genId()
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/testing/aws/full-set-platform
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/testing/aws/full-set-platform
@@ -13,6 +13,9 @@ def id = genId()
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+              label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/testing/aws/full-set-recovery
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/testing/aws/full-set-recovery
@@ -13,6 +13,9 @@ def id = genId()
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/testing/aws/full-set-security
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/testing/aws/full-set-security
@@ -13,6 +13,9 @@ def id = genId()
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/testing/aws/promote-author-standby-full-set
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/testing/aws/promote-author-standby-full-set
@@ -13,6 +13,9 @@ def id = genId()
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/jenkinsfiles/aem-opencloud/utilities/aws/encrypt-snapshots
+++ b/provisioners/jenkins/jenkinsfiles/aem-opencloud/utilities/aws/encrypt-snapshots
@@ -4,6 +4,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/todo/operations/export-package
+++ b/provisioners/jenkins/todo/operations/export-package
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/provisioners/jenkins/todo/platform-tests/production-create-full-set
+++ b/provisioners/jenkins/todo/platform-tests/production-create-full-set
@@ -6,6 +6,9 @@ def config = readJSON text: configString
 pipeline {
     agent {
         docker {
+            if (params.JENKINS_AGENT_LABEL?.trim()) {
+                label params.JENKINS_AGENT_LABEL
+            }
             image params.JENKINS_AGENT_DOCKER_IMAGE
             args params.JENKINS_AGENT_DOCKER_ARGS
         }

--- a/templates/ansible/jenkins/config/aws-resources-aem-aws-stack-builder.xml.j2
+++ b/templates/ansible/jenkins/config/aws-resources-aem-aws-stack-builder.xml.j2
@@ -19,6 +19,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/aws-resources-packer-aem.xml.j2
+++ b/templates/ansible/jenkins/config/aws-resources-packer-aem.xml.j2
@@ -19,6 +19,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-installation.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-installation.xml.j2
@@ -13,6 +13,12 @@
         <trim>true</trim>
       </hudson.model.BooleanParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-machine-images.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-machine-images.xml.j2
@@ -19,6 +19,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-manage-environments-aem-consolidated-switch-dns.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-manage-environments-aem-consolidated-switch-dns.xml.j2
@@ -43,6 +43,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-manage-environments-aem-delete.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-manage-environments-aem-delete.xml.j2
@@ -25,6 +25,12 @@
         <trim>true</trim>
       </hudson.model.BooleanParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-manage-environments-aem-full-set-switch-dns.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-manage-environments-aem-full-set-switch-dns.xml.j2
@@ -43,6 +43,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-manage-environments-aem-stack-manager.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-manage-environments-aem-stack-manager.xml.j2
@@ -25,6 +25,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_ARGS</name>
         <description>The CLI args for Jenkins to use when running Docker CLI.</description>
         <defaultValue>{{ jenkins.agent.docker_args }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-manage-environments-aem.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-manage-environments-aem.xml.j2
@@ -49,6 +49,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-migration-aem-reconfiguration.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-migration-aem-reconfiguration.xml.j2
@@ -31,6 +31,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-migration-aem-upgrade-export-import.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-migration-aem-upgrade-export-import.xml.j2
@@ -31,6 +31,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-migration-aem-upgrade-in-place.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-migration-aem-upgrade-in-place.xml.j2
@@ -55,6 +55,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-operational-tasks-aem-profile.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-operational-tasks-aem-profile.xml.j2
@@ -88,6 +88,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-operational-tasks-authorpublish-component.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-operational-tasks-authorpublish-component.xml.j2
@@ -37,6 +37,12 @@
         </choices>
       </hudson.model.ChoiceParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-operational-tasks-deploy-package.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-operational-tasks-deploy-package.xml.j2
@@ -100,6 +100,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-operational-tasks-deployment-descriptor.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-operational-tasks-deployment-descriptor.xml.j2
@@ -31,6 +31,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-operational-tasks-disable-saml.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-operational-tasks-disable-saml.xml.j2
@@ -46,6 +46,12 @@
         </choices>
       </hudson.model.ChoiceParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-operational-tasks-dispatcher-component.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-operational-tasks-dispatcher-component.xml.j2
@@ -36,6 +36,12 @@
         </choices>
       </hudson.model.ChoiceParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-operational-tasks-enable-saml.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-operational-tasks-enable-saml.xml.j2
@@ -150,6 +150,12 @@
         <description>SP_PRIVATE_KEY_ALIAS</description>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-operational-tasks-export-descriptor.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-operational-tasks-export-descriptor.xml.j2
@@ -31,6 +31,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-operational-tasks-export-package.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-operational-tasks-export-package.xml.j2
@@ -64,6 +64,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-operational-tasks-import-package.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-operational-tasks-import-package.xml.j2
@@ -70,6 +70,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-operational-tasks-test-aem-security.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-operational-tasks-test-aem-security.xml.j2
@@ -36,6 +36,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-operational-tasks-test-architecture-type.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-operational-tasks-test-architecture-type.xml.j2
@@ -34,6 +34,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-operational-tasks-test-recovery.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-operational-tasks-test-recovery.xml.j2
@@ -35,6 +35,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-operational-tasks-test.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-operational-tasks-test.xml.j2
@@ -25,6 +25,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-operational-tasks.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-operational-tasks.xml.j2
@@ -25,6 +25,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-testing-blue-green.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-testing-blue-green.xml.j2
@@ -37,6 +37,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-testing-consolidated-security.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-testing-consolidated-security.xml.j2
@@ -49,6 +49,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-testing-platform.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-testing-platform.xml.j2
@@ -115,6 +115,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-testing-security.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-testing-security.xml.j2
@@ -61,6 +61,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-testing.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-testing.xml.j2
@@ -37,6 +37,12 @@
         <trim>true</trim>
       </hudson.model.StringParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs-utilities-encrypt-aws-snapshots.xml.j2
+++ b/templates/ansible/jenkins/config/jobs-utilities-encrypt-aws-snapshots.xml.j2
@@ -56,6 +56,12 @@
         <trim>true</trim>
       </hudson.model.BooleanParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>

--- a/templates/ansible/jenkins/config/jobs.xml.j2
+++ b/templates/ansible/jenkins/config/jobs.xml.j2
@@ -13,6 +13,12 @@
         <trim>true</trim>
       </hudson.model.BooleanParameterDefinition>
       <hudson.model.StringParameterDefinition>
+        <name>JENKINS_AGENT_LABEL</name>
+        <description>The label of Jenkins build pipeline agent, leave empty if no label needed.</description>
+        <defaultValue>{{ jenkins.agent.label }}</defaultValue>
+        <trim>true</trim>
+      </hudson.model.StringParameterDefinition>
+      <hudson.model.StringParameterDefinition>
         <name>JENKINS_AGENT_DOCKER_IMAGE</name>
         <description>The name of Docker image to be used as Jenkins build pipeline agent.</description>
         <defaultValue>{{ jenkins.agent.docker_image }}</defaultValue>


### PR DESCRIPTION
This PR adds `jenkins_agent.label` configuration support. Which by default has an empty value and preserves the original behaviour which doesn't choose any specific Jenkins build agent. When the configuration property is set with a label value, then the pipelines will only be executed on Jenkins build agents which have the corresponding label.

This has been tested with both scenarios:
- User config doesn't have any jenkins_agent.label property, so the pipelines would run across any Jenkins build agent
- User config having jenkins_agent.label property with specific value, so the pipelines would run only on the Jenkins build agents with the corresponding label

Note that the label property is added to docker property within the Jenkinsfile, as it's not possible to add label property on the same level as docker property. Adding the label within docker property provides the expected behaviour, which is to identify Jenkins build agent labels.