### PR TITLE
Upgrade AEM OpenCloud libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Upgrade AEM AWS Stack Builder to 5.15.0
+- Upgrade AEM AWS Stack Builder to 5.16.0
+- Upgrade Packer AEM to 5.16.0
+- Upgrade AEM Test Suite to 2.9.0
 
 ## 5.14.0 - 2022-08-26
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade AEM AWS Stack Builder to 5.16.0
 - Upgrade Packer AEM to 5.16.0
 - Upgrade AEM Test Suite to 2.9.0
+- Update Docker image to shinesolutions/aem-platform-buildenv:3.2.0
 
 ## 5.14.0 - 2022-08-26
 ### Changed

--- a/conf/ansible/inventory/group_vars/defaults.yaml
+++ b/conf/ansible/inventory/group_vars/defaults.yaml
@@ -39,11 +39,11 @@ jenkins:
   protocol: http
   host: overwrite-me
   port: 8080
-  username: overwrite-me
-  password: overwrite-me
+  username: admin
+  password: 11e8f4638e7b0201246a3b162401f9fd94
   agent:
     label: ''
-    docker_image: shinesolutions/aem-platform-buildenv:3.0.0
+    docker_image: shinesolutions/aem-platform-buildenv:3.2.0
     docker_args: ''
   os:
     jenkins_home: null

--- a/resources/aem_opencloud/config.json
+++ b/resources/aem_opencloud/config.json
@@ -1,8 +1,8 @@
 {
   "library": {
-    "packer_aem": "5.15.1",
-    "aem_aws_stack_builder": "5.15.0",
+    "packer_aem": "5.16.0",
+    "aem_aws_stack_builder": "5.16.0",
     "aem_stack_manager_messenger": "2.15.0",
-    "aem_test_suite": "2.8.0"
+    "aem_test_suite": "2.9.0"
   }
 }


### PR DESCRIPTION
### Changed
- Upgrade AEM AWS Stack Builder to 5.16.0
- Upgrade Packer AEM to 5.16.0
- Upgrade AEM Test Suite to 2.9.0
- Update Docker image to shinesolutions/aem-platform-buildenv:3.2.0