### PR TITLE
Upgrade Packer AEM to 5.15.2 & AEM AWS Stack Builder to 5.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Upgrade Packer AEM to 5.15.2
+- Upgrade AEM AWS Stack Builder to 5.14.2
 
 ## 5.13.2 - 2023-05-31
 ### Changed

--- a/resources/aem_opencloud/config.json
+++ b/resources/aem_opencloud/config.json
@@ -1,7 +1,7 @@
 {
   "library": {
-    "packer_aem": "5.15.1",
-    "aem_aws_stack_builder": "5.14.1",
+    "packer_aem": "5.15.2",
+    "aem_aws_stack_builder": "5.14.2",
     "aem_stack_manager_messenger": "2.15.0",
     "aem_test_suite": "2.7.3"
   }


### PR DESCRIPTION
### Changed
- Upgrade Packer AEM to 5.15.2
- Upgrade AEM AWS Stack Builder to 5.14.2
